### PR TITLE
Timeline: update days to match listed dates

### DIFF
--- a/programme.html
+++ b/programme.html
@@ -199,28 +199,28 @@
                         <div class="timeline">
                             <div class="t-container left">
                                 <div class="content">
-                                    <h4>Tuesday<br>
+                                    <h4>Wednesday<br>
                                         March 21 </h4>
                                     <p>Call for presentations closes</p>
                                 </div>
                             </div>
                             <div class="t-container right">
                                 <div class="content">
-                                    <h4>Monday<br>
+                                    <h4>Saturday<br>
                                         March 31 </h4>
                                     <p>Community voting opens</p>
                                 </div>
                             </div>
                             <div class="t-container left">
                                 <div class="content">
-                                    <h4>Monday<br>
+                                    <h4>Saturday<br>
                                         April 14 </h4>
                                     <p>Community voting closes</p>
                                 </div>
                             </div>
                             <div class="t-container right">
                                 <div class="content">
-                                    <h4>Monday<br>
+                                    <h4>Sunday<br>
                                         May 1 </h4>
                                     <p> Accepted presentations announced </p>
                                 </div>

--- a/programme.html
+++ b/programme.html
@@ -220,7 +220,7 @@
                             </div>
                             <div class="t-container right">
                                 <div class="content">
-                                    <h4>Sunday<br>
+                                    <h4>Tuesday<br>
                                         May 1 </h4>
                                     <p> Accepted presentations announced </p>
                                 </div>


### PR DESCRIPTION
Fix days to match dates on the programme timeline. Have picked the actual dates as leading for now, since that's a) less ambiguous than going to look for the nearest matching day, and b) that's how HOT has communicated it to our community up til now